### PR TITLE
change code blocks from bash to properties for accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ A resouse pack for java and bedrock that adds custom ranks like better ranks for
 
 
 ## Java Pack Download
-```bash
+```properties
 resource-pack=https://nauticalhosting.org/Nautical-Ranks-V2-JAVA.zip
 ```
-```bash
+```properties
 resource-pack-sha1=23ca51f727bd9c29754d802900b3e38bc555411b
 ```
 


### PR DESCRIPTION
For accessibility and syntax highlighting, I've changed the language of the code blocks in the README.md file from bash to properties.

Here's an example of the difference:
```bash
bash=false
```

```properties
properties=true
```